### PR TITLE
Add settings supported and activate on install

### DIFF
--- a/Samples/WidgetAdvSampleCS/Package.appxmanifest
+++ b/Samples/WidgetAdvSampleCS/Package.appxmanifest
@@ -52,6 +52,8 @@
               <GameBarWidget Type="Standard">
                 <HomeMenuVisible>true</HomeMenuVisible>
                 <PinningSupported>true</PinningSupported>
+                <SettingsSupported AppExtensionId="Widget1Settings" />
+                <ActivateAfterInstall>true</ActivateAfterInstall>
                 <Window>
                   <Size>
                     <Height>625</Height>


### PR DESCRIPTION
Missing settings supported and activate on install tags in order to hook up the settings ID to parent tag.