### PR TITLE
Add to samples for how to enable proper transparency support

### DIFF
--- a/Samples/WidgetAdvSample/App.xaml
+++ b/Samples/WidgetAdvSample/App.xaml
@@ -2,6 +2,4 @@
     x:Class="WidgetAdvSample.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetAdvSample">
-
-</Application>
+    xmlns:local="using:WidgetAdvSample" />

--- a/Samples/WidgetAdvSample/MainPage.xaml
+++ b/Samples/WidgetAdvSample/MainPage.xaml
@@ -2,13 +2,16 @@
     x:Class="WidgetAdvSample.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetAdvSample"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WidgetAdvSample"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <TextBlock Text="MainPage" Padding="0,0,0,5"/>
-       <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
+    <StackPanel
+        HorizontalAlignment="Center"
+        VerticalAlignment="Center"
+        Orientation="Vertical">
+        <TextBlock Padding="0,0,0,5" Text="MainPage" />
+        <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
     </StackPanel>
 </Page>

--- a/Samples/WidgetAdvSample/Package.appxmanifest
+++ b/Samples/WidgetAdvSample/Package.appxmanifest
@@ -142,6 +142,7 @@
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetActivatedEventArgsPrivate" InterfaceId="782535A7-9407-4572-BFCB-316B4086F102" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost" InterfaceId="5D12BC93-212B-4B9F-9091-76B73BF56525" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate" InterfaceId="22ABA97F-FB0F-4439-9BDD-2C67B2D5AA8F" />
+        <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate2" InterfaceId="B2F7DB8C-7540-48DA-9B46-4E60CE0D9DEB" />
       </ProxyStub>
     </Extension>
   </Extensions>

--- a/Samples/WidgetAdvSample/Package.appxmanifest
+++ b/Samples/WidgetAdvSample/Package.appxmanifest
@@ -141,6 +141,7 @@
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarNavigationKeyCombo" InterfaceId="5EEA3DBF-09BB-42A5-B491-CF561E33C172" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetActivatedEventArgsPrivate" InterfaceId="782535A7-9407-4572-BFCB-316B4086F102" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost" InterfaceId="5D12BC93-212B-4B9F-9091-76B73BF56525" />
+        <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost2" InterfaceId="28717C8B-D8E8-47A8-AF47-A1D5263BAE9B" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate" InterfaceId="22ABA97F-FB0F-4439-9BDD-2C67B2D5AA8F" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate2" InterfaceId="B2F7DB8C-7540-48DA-9B46-4E60CE0D9DEB" />
       </ProxyStub>

--- a/Samples/WidgetAdvSample/Widget1.cpp
+++ b/Samples/WidgetAdvSample/Widget1.cpp
@@ -2,6 +2,7 @@
 #include "Widget1.h"
 #include "Widget1.g.cpp"
 
+#include <sstream>
 #include <strsafe.h>
 
 using namespace winrt;
@@ -33,6 +34,7 @@ namespace winrt::WidgetAdvSample::implementation
         m_settingsToken = m_widget.SettingsClicked({ this, &Widget1::SettingsButton_Click });
         m_favoritedChangedToken = m_widget.FavoritedChanged({ this, &Widget1::FavoritedChanged });
         m_displayModeChangedToken = m_widget.GameBarDisplayModeChanged({ this, &Widget1::GameBarDisplayModeChanged });
+        m_opacityChangedToken = m_widget.RequestedOpacityChanged({ this, &Widget1::RequestedOpacityChanged });
         m_pinnedChangedToken = m_widget.PinnedChanged({ this, &Widget1::PinnedChanged });
         m_themeChangedToken = m_widget.RequestedThemeChanged({ this, &Widget1::RequestedThemeChanged });
         m_visibleChangedToken = m_widget.VisibleChanged({ this, &Widget1::VisibleChanged });
@@ -40,6 +42,7 @@ namespace winrt::WidgetAdvSample::implementation
 
         PinnedStateTextBlock().Text(PinnedStateToString());
         FavoritedTextBlock().Text(FavoritedStateToString());
+        RequestedOpacityTextBlock().Text(RequestedOpacityToString());
         RequestedThemeTextBlock().Text(RequestedThemeToString());
 
         HorizontalResizeSupportedCheckBox().IsChecked(m_widget.HorizontalResizeSupported());
@@ -58,6 +61,7 @@ namespace winrt::WidgetAdvSample::implementation
         MaxWindowWidthBox().Text(buffer);
 
         SetBackgroundColor();
+        SetBackgroundOpacity();
         OutputGameBarDisplayMode();
         OutputVisibleState();
         OutputWindowState();
@@ -238,6 +242,14 @@ namespace winrt::WidgetAdvSample::implementation
         PinnedStateTextBlock().Text(PinnedStateToString());
     }
 
+    fire_and_forget Widget1::RequestedOpacityChanged(IInspectable const& /*sender*/, IInspectable const& /*e*/)
+    {
+        auto strongThis{ get_strong() };
+        co_await resume_foreground(BackgroundGrid().Dispatcher());
+        RequestedOpacityTextBlock().Text(RequestedOpacityToString());
+        SetBackgroundOpacity();
+    }
+
     fire_and_forget  Widget1::RequestedThemeChanged(IInspectable const& /*sender*/, IInspectable const& /*e*/)
     {
         auto strongThis{ get_strong() };
@@ -263,13 +275,30 @@ namespace winrt::WidgetAdvSample::implementation
         if (requestedTheme == ElementTheme::Dark)
         {
             this->RequestedTheme(requestedTheme);
-            this->Background(m_widgetDarkThemeBrush);
+            BackgroundGrid().Background(m_widgetDarkThemeBrush);
         }
         else
         {
             this->RequestedTheme(requestedTheme);
-            this->Background(m_widgetLightThemeBrush);
+            this->BackgroundGrid().Background(m_widgetLightThemeBrush);
         }
+
+        BackgroundGrid().Opacity(m_widget.RequestedOpacity());
+    }
+
+    void Widget1::SetBackgroundOpacity()
+    {
+        BackgroundGrid().Opacity(m_widget.RequestedOpacity());
+    }
+
+    hstring Widget1::RequestedOpacityToString()
+    {
+        auto requestedOpacity = m_widget.RequestedOpacity();
+
+        std::wstringstream opacityStringStream;
+        opacityStringStream << requestedOpacity;
+
+        return opacityStringStream.str().c_str();
     }
 
     hstring Widget1::RequestedThemeToString()

--- a/Samples/WidgetAdvSample/Widget1.h
+++ b/Samples/WidgetAdvSample/Widget1.h
@@ -43,12 +43,15 @@ namespace winrt::WidgetAdvSample::implementation
         winrt::fire_and_forget FavoritedChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::Foundation::IInspectable const& e);
         void GameBarDisplayModeChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::Foundation::IInspectable const& e);
         winrt::fire_and_forget PinnedChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::Foundation::IInspectable const& e);
+        winrt::fire_and_forget RequestedOpacityChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::Foundation::IInspectable const& e);
         winrt::fire_and_forget RequestedThemeChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::Foundation::IInspectable const& e);
         void VisibleChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::Foundation::IInspectable const& e);
         void WindowStateChanged(winrt::Windows::Foundation::IInspectable const& sender, winrt::Windows::Foundation::IInspectable const& e);
         
         // Methods to handle updating of Text and UI
         void SetBackgroundColor();
+        void SetBackgroundOpacity();
+        hstring RequestedOpacityToString();
         hstring RequestedThemeToString();
         hstring FavoritedStateToString();
         hstring PinnedStateToString();
@@ -68,6 +71,7 @@ namespace winrt::WidgetAdvSample::implementation
         winrt::event_token m_favoritedChangedToken{};
         winrt::event_token m_displayModeChangedToken{};
         winrt::event_token m_pinnedChangedToken{};
+        winrt::event_token m_opacityChangedToken{};
         winrt::event_token m_themeChangedToken{};
         winrt::event_token m_visibleChangedToken{};
         winrt::event_token m_windowStateChangedToken{};

--- a/Samples/WidgetAdvSample/Widget1.xaml
+++ b/Samples/WidgetAdvSample/Widget1.xaml
@@ -2,181 +2,421 @@
     x:Class="WidgetAdvSample.Widget1"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetAdvSample"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WidgetAdvSample"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-  <Grid >
-    <ScrollViewer VerticalScrollBarVisibility="Visible"
-                  HorizontalScrollBarVisibility="Auto">
-      <StackPanel Orientation="Vertical" Padding="10" >
-        <Grid Padding="2">
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="*" />
-          </Grid.ColumnDefinitions>
-          <TextBlock Grid.Column="0" Text="AppId: " VerticalAlignment="Center" />
-          <TextBox Grid.Column="1" x:Name="ActivateAsyncAppId" Text="App"/>
-        </Grid>
-        <Grid Padding="2">
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="*" />
-          </Grid.ColumnDefinitions>
-          <TextBlock Grid.Column="0" Text="AppExtensionId: " VerticalAlignment="Center" />
-          <TextBox Grid.Column="1" x:Name="ActivateAsyncAppExtId" Text="Widget2"/>
-        </Grid>
-        <StackPanel Orientation="Vertical" HorizontalAlignment="Left" Padding="2">
-          <Button x:Name="ActivateAsyncAppExtIdButton" Click="ActivateAsyncAppExtIdButton_Click" Margin="0,2">ActivateAsync(appExtensionId)</Button>
-          <Button x:Name="ActivateAsyncAppIdButton" Click="ActivateAsyncAppIdButton_Click" Margin="0,2">ActivateAsync(appId, appExtensionId)</Button>
-          <Button x:Name="MinimizeAsyncAppExtIdButton" Click="MinimizeAsyncAppExtIdButton_Click" Margin="0,2">MinimizeAsync(appExtensionId)</Button>
-          <Button x:Name="MinimizeAsyncAppIdButton" Click="MinimizeAsyncAppIdButton_Click" Margin="0,2">MinimizeAsync(appId, appExtensionId)</Button>
-          <Button x:Name="RestoreAsyncAppExtIdButton" Click="RestoreAsyncAppExtIdButton_Click" Margin="0,2">RestoreAsync(appExtensionId)</Button>
-          <Button x:Name="RestoreAsyncAppIdButton" Click="RestoreAsyncAppIdButton_Click" Margin="0,2">RestoreAsync(appId, appExtensionId)</Button>
-          <Button x:Name="CloseAsyncAppExtIdButton" Click="CloseAsyncAppExtIdButton_Click" Margin="0,2">CloseAsync(appExtensionId)</Button>
-          <Button x:Name="CloseAsyncAppIdButton" Click="CloseAsyncAppIdButton_Click" Margin="0,2">CloseAsync(appId, appExtensionId)</Button>
-        </StackPanel>
-        <Grid Padding="2">
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="*" />
-          </Grid.ColumnDefinitions>
-          <TextBlock Grid.Column="0" Text="Uri: " VerticalAlignment="Center" />
-          <TextBox Grid.Column="1" x:Name="ActivateAsyncUri" VerticalAlignment="Center" Text="ms-gamebar:activate/WidgetAdvSample_8wekyb3d8bbwe_App_Widget2/?var=value"/>
-        </Grid>
-        <Button x:Name="ActivateWithUriAsyncButton" Click="ActivateWithUriAsyncButton_Click" Margin="0,2">ActivateWithUriAsync(uri)</Button>
-        <Grid Padding="2">
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="*" />
-          </Grid.ColumnDefinitions>
-          <Grid.RowDefinitions>
-            <RowDefinition />
-            <RowDefinition />
-          </Grid.RowDefinitions>
-          <TextBlock Grid.Column="0" Grid.Row="0" Text="Window Width: " VerticalAlignment="Center" />
-          <TextBox Grid.Column="1" Grid.Row="0" x:Name="WindowWidthBox" VerticalAlignment="Center" Text="800"/>
-          <TextBlock Grid.Column="0" Grid.Row="1" Text="Window Height: " VerticalAlignment="Center" />
-          <TextBox Grid.Column="1" Grid.Row="1" x:Name="WindowHeightBox" VerticalAlignment="Center" Text="800"/>
-        </Grid>
-        <Button x:Name="TryResizeWindowAsync" Click="TryResizeWindowAsync_Click" Margin="0,2">TryResizeWindowAsync</Button>
-        <Grid Padding="2">
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="*" />
-          </Grid.ColumnDefinitions>
-          <Grid.RowDefinitions>
-            <RowDefinition />
-            <RowDefinition />
-          </Grid.RowDefinitions>
-          <TextBlock Grid.Column="0" Grid.Row="0" Text="Request URI: " VerticalAlignment="Center" />
-          <TextBox Grid.Column="1" Grid.Row="0" x:Name="RequestUriBox" VerticalAlignment="Center" />
-          <TextBlock Grid.Column="0" Grid.Row="1" Text="Callback URI: " VerticalAlignment="Center" />
-          <TextBox Grid.Column="1" Grid.Row="1" x:Name="CallbackUriBox" VerticalAlignment="Center" />
-        </Grid>
-        <Button x:Name="AuthenticateAsync" Click="AuthenticateAsync_Click" Margin="0,2">AuthenticateAsync</Button>
-        <StackPanel>
-          <Grid Padding="2">
-            <Grid.ColumnDefinitions>
-              <ColumnDefinition Width="*" />
-              <ColumnDefinition Width="5*" />
-            </Grid.ColumnDefinitions>
-            <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="Pinned:" />
-            <TextBlock Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" x:Name="PinnedStateTextBlock" />
-          </Grid>
-        </StackPanel>
-        <StackPanel>
-          <Grid Padding="2">
-            <Grid.ColumnDefinitions>
-              <ColumnDefinition Width="*" />
-              <ColumnDefinition Width="5*" />
-            </Grid.ColumnDefinitions>
-            <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="Theme:" />
-            <TextBlock Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" x:Name="RequestedThemeTextBlock" />
-          </Grid>
-        </StackPanel>
-        <StackPanel>
-          <Grid Padding="2">
-            <Grid.ColumnDefinitions>
-              <ColumnDefinition Width="*" />
-              <ColumnDefinition Width="5*" />
-            </Grid.ColumnDefinitions>
-            <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="Favorited:" />
-            <TextBlock Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" x:Name="FavoritedTextBlock" />
-          </Grid>
-        </StackPanel>
-        <StackPanel>
-          <Grid Padding="2">
-            <Grid.ColumnDefinitions>
-              <ColumnDefinition Width="*" />
-              <ColumnDefinition Width="5*" />
-            </Grid.ColumnDefinitions>
-            <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="HorizontalResizeSupported:" />
-            <CheckBox Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" x:Name="HorizontalResizeSupportedCheckBox" Padding="2" Checked="HorizontalResizeSupportedCheckBox_Checked" Unchecked="HorizontalResizeSupportedCheckBox_Unchecked" />
-          </Grid>
-        </StackPanel>
-        <StackPanel>
-          <Grid Padding="2">
-            <Grid.ColumnDefinitions>
-              <ColumnDefinition Width="*" />
-              <ColumnDefinition Width="5*" />
-            </Grid.ColumnDefinitions>
-            <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="VerticalResizeSupported:" />
-            <CheckBox Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" x:Name="VerticalResizeSupportedCheckBox" Padding="2" Checked="VerticalResizeSupportedCheckBox_Checked" Unchecked="VerticalResizeSupportedCheckBox_Unchecked" />
-          </Grid>
-        </StackPanel>
-        <StackPanel>
-          <Grid Padding="2">
-            <Grid.ColumnDefinitions>
-              <ColumnDefinition Width="*" />
-              <ColumnDefinition Width="5*" />
-            </Grid.ColumnDefinitions>
-            <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="PinningSupported:" />
-            <CheckBox Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" x:Name="PinningSupportedCheckBox" Padding="2" Checked="PinningSupportedCheckBox_Checked" Unchecked="PinningSupportedCheckBox_Unchecked" />
-          </Grid>
-        </StackPanel>
-        <StackPanel>
-          <Grid Padding="2">
-            <Grid.ColumnDefinitions>
-              <ColumnDefinition Width="*" />
-              <ColumnDefinition Width="5*" />
-            </Grid.ColumnDefinitions>
-            <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="SettingsSupported:" />
-            <CheckBox Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" x:Name="SettingsSupportedCheckBox" Padding="2" Checked="SettingsSupportedCheckBox_Checked" Unchecked="SettingsSupportedCheckBox_Unchecked" />
-          </Grid>
-        </StackPanel>
-        <Grid Padding="2">
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="*" />
-          </Grid.ColumnDefinitions>
-          <Grid.RowDefinitions>
-            <RowDefinition />
-            <RowDefinition />
-          </Grid.RowDefinitions>
-          <TextBlock Grid.Column="0" Grid.Row="0" Text="Min Window Width: " VerticalAlignment="Center" />
-          <TextBox Grid.Column="1" Grid.Row="0" x:Name="MinWindowWidthBox" VerticalAlignment="Center" />
-          <TextBlock Grid.Column="0" Grid.Row="1" Text="Min Window Height: " VerticalAlignment="Center" />
-          <TextBox Grid.Column="1" Grid.Row="1" x:Name="MinWindowHeightBox" VerticalAlignment="Center" />
-        </Grid>
-        <Button x:Name="MinWindowSizeButton" Click="MinWindowSize_Click" Margin="0,2">Set MinWindowSize</Button>
-        <Grid Padding="2">
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="*" />
-          </Grid.ColumnDefinitions>
-          <Grid.RowDefinitions>
-            <RowDefinition />
-            <RowDefinition />
-          </Grid.RowDefinitions>
-          <TextBlock Grid.Column="0" Grid.Row="0" Text="Max Window Width: " VerticalAlignment="Center" />
-          <TextBox Grid.Column="1" Grid.Row="0" x:Name="MaxWindowWidthBox" VerticalAlignment="Center" />
-          <TextBlock Grid.Column="0" Grid.Row="1" Text="Max Window Height: " VerticalAlignment="Center" />
-          <TextBox Grid.Column="1" Grid.Row="1" x:Name="MaxWindowHeightBox" VerticalAlignment="Center" />
-        </Grid>
-        <Button x:Name="MaxWindowSizeButton" Click="MaxWindowSize_Click" Margin="0,2">Set MaxWindowSize</Button>
-      </StackPanel>
-    </ScrollViewer>
-  </Grid>
+    <Grid>
+        <Grid x:Name="BackgroundGrid" />
+
+        <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Visible">
+            <StackPanel Padding="10" Orientation="Vertical">
+                <Grid Padding="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="AppId: " />
+                    <TextBox
+                        x:Name="ActivateAsyncAppId"
+                        Grid.Column="1"
+                        Text="App" />
+                </Grid>
+                <Grid Padding="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="AppExtensionId: " />
+                    <TextBox
+                        x:Name="ActivateAsyncAppExtId"
+                        Grid.Column="1"
+                        Text="Widget2" />
+                </Grid>
+                <StackPanel
+                    Padding="2"
+                    HorizontalAlignment="Left"
+                    Orientation="Vertical">
+                    <Button
+                        x:Name="ActivateAsyncAppExtIdButton"
+                        Margin="0,2"
+                        Click="ActivateAsyncAppExtIdButton_Click">
+                        ActivateAsync(appExtensionId)
+                    </Button>
+                    <Button
+                        x:Name="ActivateAsyncAppIdButton"
+                        Margin="0,2"
+                        Click="ActivateAsyncAppIdButton_Click">
+                        ActivateAsync(appId, appExtensionId)
+                    </Button>
+                    <Button
+                        x:Name="MinimizeAsyncAppExtIdButton"
+                        Margin="0,2"
+                        Click="MinimizeAsyncAppExtIdButton_Click">
+                        MinimizeAsync(appExtensionId)
+                    </Button>
+                    <Button
+                        x:Name="MinimizeAsyncAppIdButton"
+                        Margin="0,2"
+                        Click="MinimizeAsyncAppIdButton_Click">
+                        MinimizeAsync(appId, appExtensionId)
+                    </Button>
+                    <Button
+                        x:Name="RestoreAsyncAppExtIdButton"
+                        Margin="0,2"
+                        Click="RestoreAsyncAppExtIdButton_Click">
+                        RestoreAsync(appExtensionId)
+                    </Button>
+                    <Button
+                        x:Name="RestoreAsyncAppIdButton"
+                        Margin="0,2"
+                        Click="RestoreAsyncAppIdButton_Click">
+                        RestoreAsync(appId, appExtensionId)
+                    </Button>
+                    <Button
+                        x:Name="CloseAsyncAppExtIdButton"
+                        Margin="0,2"
+                        Click="CloseAsyncAppExtIdButton_Click">
+                        CloseAsync(appExtensionId)
+                    </Button>
+                    <Button
+                        x:Name="CloseAsyncAppIdButton"
+                        Margin="0,2"
+                        Click="CloseAsyncAppIdButton_Click">
+                        CloseAsync(appId, appExtensionId)
+                    </Button>
+                </StackPanel>
+                <Grid Padding="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="Uri: " />
+                    <TextBox
+                        x:Name="ActivateAsyncUri"
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        Text="ms-gamebar:activate/WidgetAdvSample_8wekyb3d8bbwe_App_Widget2/?var=value" />
+                </Grid>
+                <Button
+                    x:Name="ActivateWithUriAsyncButton"
+                    Margin="0,2"
+                    Click="ActivateWithUriAsyncButton_Click">
+                    ActivateWithUriAsync(uri)
+                </Button>
+                <Grid Padding="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+                    <TextBlock
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="Window Width: " />
+                    <TextBox
+                        x:Name="WindowWidthBox"
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        Text="800" />
+                    <TextBlock
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="Window Height: " />
+                    <TextBox
+                        x:Name="WindowHeightBox"
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        Text="800" />
+                </Grid>
+                <Button
+                    x:Name="TryResizeWindowAsync"
+                    Margin="0,2"
+                    Click="TryResizeWindowAsync_Click">
+                    TryResizeWindowAsync
+                </Button>
+                <Grid Padding="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+                    <TextBlock
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="Request URI: " />
+                    <TextBox
+                        x:Name="RequestUriBox"
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        VerticalAlignment="Center" />
+                    <TextBlock
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="Callback URI: " />
+                    <TextBox
+                        x:Name="CallbackUriBox"
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        VerticalAlignment="Center" />
+                </Grid>
+                <Button
+                    x:Name="AuthenticateAsync"
+                    Margin="0,2"
+                    Click="AuthenticateAsync_Click">
+                    AuthenticateAsync
+                </Button>
+                <StackPanel>
+                    <Grid Padding="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="5*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Text="Pinned:" />
+                        <TextBlock
+                            x:Name="PinnedStateTextBlock"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            VerticalAlignment="Center" />
+                    </Grid>
+                </StackPanel>
+                <StackPanel>
+                    <Grid Padding="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="5*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Text="Opacity:" />
+                        <TextBlock
+                            x:Name="RequestedOpacityTextBlock"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            VerticalAlignment="Center" />
+                    </Grid>
+                </StackPanel>
+                <StackPanel>
+                    <Grid Padding="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="5*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Text="Theme:" />
+                        <TextBlock
+                            x:Name="RequestedThemeTextBlock"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            VerticalAlignment="Center" />
+                    </Grid>
+                </StackPanel>
+                <StackPanel>
+                    <Grid Padding="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="5*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Text="Favorited:" />
+                        <TextBlock
+                            x:Name="FavoritedTextBlock"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            VerticalAlignment="Center" />
+                    </Grid>
+                </StackPanel>
+                <StackPanel>
+                    <Grid Padding="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="5*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Text="HorizontalResizeSupported:" />
+                        <CheckBox
+                            x:Name="HorizontalResizeSupportedCheckBox"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            Padding="2"
+                            VerticalAlignment="Center"
+                            Checked="HorizontalResizeSupportedCheckBox_Checked"
+                            Unchecked="HorizontalResizeSupportedCheckBox_Unchecked" />
+                    </Grid>
+                </StackPanel>
+                <StackPanel>
+                    <Grid Padding="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="5*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Text="VerticalResizeSupported:" />
+                        <CheckBox
+                            x:Name="VerticalResizeSupportedCheckBox"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            Padding="2"
+                            VerticalAlignment="Center"
+                            Checked="VerticalResizeSupportedCheckBox_Checked"
+                            Unchecked="VerticalResizeSupportedCheckBox_Unchecked" />
+                    </Grid>
+                </StackPanel>
+                <StackPanel>
+                    <Grid Padding="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="5*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Text="PinningSupported:" />
+                        <CheckBox
+                            x:Name="PinningSupportedCheckBox"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            Padding="2"
+                            VerticalAlignment="Center"
+                            Checked="PinningSupportedCheckBox_Checked"
+                            Unchecked="PinningSupportedCheckBox_Unchecked" />
+                    </Grid>
+                </StackPanel>
+                <StackPanel>
+                    <Grid Padding="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="5*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Text="SettingsSupported:" />
+                        <CheckBox
+                            x:Name="SettingsSupportedCheckBox"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            Padding="2"
+                            VerticalAlignment="Center"
+                            Checked="SettingsSupportedCheckBox_Checked"
+                            Unchecked="SettingsSupportedCheckBox_Unchecked" />
+                    </Grid>
+                </StackPanel>
+                <Grid Padding="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+                    <TextBlock
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="Min Window Width: " />
+                    <TextBox
+                        x:Name="MinWindowWidthBox"
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        VerticalAlignment="Center" />
+                    <TextBlock
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="Min Window Height: " />
+                    <TextBox
+                        x:Name="MinWindowHeightBox"
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        VerticalAlignment="Center" />
+                </Grid>
+                <Button
+                    x:Name="MinWindowSizeButton"
+                    Margin="0,2"
+                    Click="MinWindowSize_Click">
+                    Set MinWindowSize
+                </Button>
+                <Grid Padding="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+                    <TextBlock
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="Max Window Width: " />
+                    <TextBox
+                        x:Name="MaxWindowWidthBox"
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        VerticalAlignment="Center" />
+                    <TextBlock
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="Max Window Height: " />
+                    <TextBox
+                        x:Name="MaxWindowHeightBox"
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        VerticalAlignment="Center" />
+                </Grid>
+                <Button
+                    x:Name="MaxWindowSizeButton"
+                    Margin="0,2"
+                    Click="MaxWindowSize_Click">
+                    Set MaxWindowSize
+                </Button>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
 </Page>

--- a/Samples/WidgetAdvSample/Widget1Settings.xaml
+++ b/Samples/WidgetAdvSample/Widget1Settings.xaml
@@ -2,12 +2,19 @@
     x:Class="WidgetAdvSample.Widget1Settings"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetAdvSample"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WidgetAdvSample"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <Button x:Name="Button" Click="ClickHandler">Click Me</Button>
-    </StackPanel>
+    <Grid>
+        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
+
+        <StackPanel
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Orientation="Horizontal">
+            <Button x:Name="Button" Click="ClickHandler">Click Me</Button>
+        </StackPanel>
+    </Grid>
 </Page>

--- a/Samples/WidgetAdvSample/Widget2.xaml
+++ b/Samples/WidgetAdvSample/Widget2.xaml
@@ -2,15 +2,25 @@
     x:Class="WidgetAdvSample.Widget2"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetAdvSample"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WidgetAdvSample"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <TextBlock Text="Widget2" Padding="0,0,0,5"/>
-        <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
-        <TextBlock FontWeight="Bold" Text="Activation URI: " Margin="0,5,0,2"/>
-        <TextBlock x:Name="uriTextBlock" TextWrapping="WrapWholeWords" />
-    </StackPanel>
+    <Grid>
+        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
+
+        <StackPanel
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Orientation="Vertical">
+            <TextBlock Padding="0,0,0,5" Text="Widget2" />
+            <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
+            <TextBlock
+                Margin="0,5,0,2"
+                FontWeight="Bold"
+                Text="Activation URI: " />
+            <TextBlock x:Name="uriTextBlock" TextWrapping="WrapWholeWords" />
+        </StackPanel>
+    </Grid>
 </Page>

--- a/Samples/WidgetAdvSample/WidgetAdvSample.vcxproj
+++ b/Samples/WidgetAdvSample/WidgetAdvSample.vcxproj
@@ -254,7 +254,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets" Condition="Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets')" />
+    <Import Project="..\packages\Microsoft.Gaming.XboxGameBar.5.3.200512001-prerelease\build\native\Microsoft.Gaming.XboxGameBar.targets" Condition="Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200512001-prerelease\build\native\Microsoft.Gaming.XboxGameBar.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -262,6 +262,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200512001-prerelease\build\native\Microsoft.Gaming.XboxGameBar.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Gaming.XboxGameBar.5.3.200512001-prerelease\build\native\Microsoft.Gaming.XboxGameBar.targets'))" />
   </Target>
 </Project>

--- a/Samples/WidgetAdvSample/WidgetAdvSample.vcxproj
+++ b/Samples/WidgetAdvSample/WidgetAdvSample.vcxproj
@@ -254,7 +254,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Microsoft.Gaming.XboxGameBar.5.1.200401003\build\native\Microsoft.Gaming.XboxGameBar.targets" Condition="Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.1.200401003\build\native\Microsoft.Gaming.XboxGameBar.targets')" />
+    <Import Project="..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets" Condition="Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -262,6 +262,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.1.200401003\build\native\Microsoft.Gaming.XboxGameBar.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Gaming.XboxGameBar.5.1.200401003\build\native\Microsoft.Gaming.XboxGameBar.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets'))" />
   </Target>
 </Project>

--- a/Samples/WidgetAdvSample/packages.config
+++ b/Samples/WidgetAdvSample/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Gaming.XboxGameBar" version="5.3.200511002" targetFramework="native" />
+  <package id="Microsoft.Gaming.XboxGameBar" version="5.3.200512001-prerelease" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200203.5" targetFramework="native" />
 </packages>

--- a/Samples/WidgetAdvSample/packages.config
+++ b/Samples/WidgetAdvSample/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Gaming.XboxGameBar" version="5.1.200401003" targetFramework="native" />
+  <package id="Microsoft.Gaming.XboxGameBar" version="5.3.200511002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200203.5" targetFramework="native" />
 </packages>

--- a/Samples/WidgetAdvSampleCS/App.xaml
+++ b/Samples/WidgetAdvSampleCS/App.xaml
@@ -2,6 +2,4 @@
     x:Class="WidgetAdvSampleCS.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetAdvSampleCS">
-
-</Application>
+    xmlns:local="using:WidgetAdvSampleCS" />

--- a/Samples/WidgetAdvSampleCS/MainPage.xaml
+++ b/Samples/WidgetAdvSampleCS/MainPage.xaml
@@ -2,14 +2,17 @@
     x:Class="WidgetAdvSampleCS.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetAdvSampleCS"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WidgetAdvSampleCS"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
 
-    <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <TextBlock Text="MainPage" Padding="0,0,0,5"/>
+    <StackPanel
+        HorizontalAlignment="Center"
+        VerticalAlignment="Center"
+        Orientation="Vertical">
+        <TextBlock Padding="0,0,0,5" Text="MainPage" />
         <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
     </StackPanel>
 </Page>

--- a/Samples/WidgetAdvSampleCS/Package.appxmanifest
+++ b/Samples/WidgetAdvSampleCS/Package.appxmanifest
@@ -143,6 +143,7 @@
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetActivatedEventArgsPrivate" InterfaceId="782535A7-9407-4572-BFCB-316B4086F102" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost" InterfaceId="5D12BC93-212B-4B9F-9091-76B73BF56525" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate" InterfaceId="22ABA97F-FB0F-4439-9BDD-2C67B2D5AA8F" />
+        <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate2" InterfaceId="B2F7DB8C-7540-48DA-9B46-4E60CE0D9DEB" />
       </ProxyStub>
     </Extension>
   </Extensions>

--- a/Samples/WidgetAdvSampleCS/Package.appxmanifest
+++ b/Samples/WidgetAdvSampleCS/Package.appxmanifest
@@ -142,6 +142,7 @@
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarNavigationKeyCombo" InterfaceId="5EEA3DBF-09BB-42A5-B491-CF561E33C172" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetActivatedEventArgsPrivate" InterfaceId="782535A7-9407-4572-BFCB-316B4086F102" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost" InterfaceId="5D12BC93-212B-4B9F-9091-76B73BF56525" />
+        <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost2" InterfaceId="28717C8B-D8E8-47A8-AF47-A1D5263BAE9B" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate" InterfaceId="22ABA97F-FB0F-4439-9BDD-2C67B2D5AA8F" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate2" InterfaceId="B2F7DB8C-7540-48DA-9B46-4E60CE0D9DEB" />
       </ProxyStub>

--- a/Samples/WidgetAdvSampleCS/Widget1.xaml
+++ b/Samples/WidgetAdvSampleCS/Widget1.xaml
@@ -2,180 +2,421 @@
     x:Class="WidgetAdvSampleCS.Widget1"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetAdvSampleCS"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WidgetAdvSampleCS"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    mc:Ignorable="d">
 
-  <ScrollViewer VerticalScrollBarVisibility="Visible"
-                HorizontalScrollBarVisibility="Auto">
-    <StackPanel Orientation="Vertical" Padding="10">
-      <Grid Padding="2">
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" />
-          <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
-        <TextBlock Grid.Column="0" Text="AppId: " VerticalAlignment="Center" />
-        <TextBox Grid.Column="1" x:Name="ActivateAsyncAppId" Text="App"/>
-      </Grid>
-      <Grid Padding="2">
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" />
-          <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
-        <TextBlock Grid.Column="0" Text="AppExtensionId: " VerticalAlignment="Center" />
-        <TextBox Grid.Column="1" x:Name="ActivateAsyncAppExtId" Text="Widget2"/>
-      </Grid>
-      <StackPanel Orientation="Vertical" HorizontalAlignment="Left" Padding="2">
-        <Button x:Name="ActivateAsyncAppExtIdButton" Click="ActivateAsyncAppExtIdButton_Click" Margin="0,2">ActivateAsync(appExtensionId)</Button>
-        <Button x:Name="ActivateAsyncAppIdButton" Click="ActivateAsyncAppIdButton_Click" Margin="0,2">ActivateAsync(appId, appExtensionId)</Button>
-        <Button x:Name="MinimizeAsyncAppExtIdButton" Click="MinimizeAsyncAppExtIdButton_Click" Margin="0,2">MinimizeAsync(appExtensionId)</Button>
-        <Button x:Name="MinimizeAsyncAppIdButton" Click="MinimizeAsyncAppIdButton_Click" Margin="0,2">MinimizeAsync(appId, appExtensionId)</Button>
-        <Button x:Name="RestoreAsyncAppExtIdButton" Click="RestoreAsyncAppExtIdButton_Click" Margin="0,2">RestoreAsync(appExtensionId)</Button>
-        <Button x:Name="RestoreAsyncAppIdButton" Click="RestoreAsyncAppIdButton_Click" Margin="0,2">RestoreAsync(appId, appExtensionId)</Button>
-        <Button x:Name="CloseAsyncAppExtIdButton" Click="CloseAsyncAppExtIdButton_Click" Margin="0,2">CloseAsync(appExtensionId)</Button>
-        <Button x:Name="CloseAsyncAppIdButton" Click="CloseAsyncAppIdButton_Click" Margin="0,2">CloseAsync(appId, appExtensionId)</Button>
-      </StackPanel>
-      <Grid Padding="2">
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" />
-          <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
-        <TextBlock Grid.Column="0" Text="Uri: " VerticalAlignment="Center" />
-        <TextBox Grid.Column="1" x:Name="ActivateAsyncUri" VerticalAlignment="Center" Text="ms-gamebar:activate/WidgetAdvSampleCS_8wekyb3d8bbwe_App_Widget2/?var=value"/>
-      </Grid>
-      <Button x:Name="ActivateWithUriAsyncButton" Click="ActivateWithUriAsyncButton_Click" Margin="0,2">ActivateWithUriAsync(uri)</Button>
-      <Grid Padding="2">
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" />
-          <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-          <RowDefinition />
-          <RowDefinition />
-        </Grid.RowDefinitions>
-        <TextBlock Grid.Column="0" Grid.Row="0" Text="Window Width: " VerticalAlignment="Center" />
-        <TextBox Grid.Column="1" Grid.Row="0" x:Name="WindowWidthBox" VerticalAlignment="Center" Text="800"/>
-        <TextBlock Grid.Column="0" Grid.Row="1" Text="Window Height: " VerticalAlignment="Center" />
-        <TextBox Grid.Column="1" Grid.Row="1" x:Name="WindowHeightBox" VerticalAlignment="Center" Text="800"/>
-      </Grid>
-      <Button x:Name="TryResizeWindowAsync" Click="TryResizeWindowAsync_Click" Margin="0,2">TryResizeWindowAsync</Button>
-      <Grid Padding="2">
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" />
-          <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-          <RowDefinition />
-          <RowDefinition />
-        </Grid.RowDefinitions>
-        <TextBlock Grid.Column="0" Grid.Row="0" Text="Request URI: " VerticalAlignment="Center" />
-        <TextBox Grid.Column="1" Grid.Row="0" x:Name="RequestUriBox" VerticalAlignment="Center" />
-        <TextBlock Grid.Column="0" Grid.Row="1" Text="Callback URI: " VerticalAlignment="Center" />
-        <TextBox Grid.Column="1" Grid.Row="1" x:Name="CallbackUriBox" VerticalAlignment="Center" />
-      </Grid>
-      <Button x:Name="AuthenticateAsync" Click="AuthenticateAsync_Click" Margin="0,2">AuthenticateAsync</Button>
-      <StackPanel>
-        <Grid Padding="2">
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="5*" />
-          </Grid.ColumnDefinitions>
-          <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="Pinned:" />
-          <TextBlock Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" x:Name="PinnedStateTextBlock" />
-        </Grid>
-      </StackPanel>
-      <StackPanel>
-        <Grid Padding="2">
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="5*" />
-          </Grid.ColumnDefinitions>
-          <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="Theme:" />
-          <TextBlock Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" x:Name="RequestedThemeTextBlock" />
-        </Grid>
-      </StackPanel>
-      <StackPanel>
-        <Grid Padding="2">
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="5*" />
-          </Grid.ColumnDefinitions>
-          <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="Favorited:" />
-          <TextBlock Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" x:Name="FavoritedTextBlock" />
-        </Grid>
-      </StackPanel>
-      <StackPanel>
-        <Grid Padding="2">
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="5*" />
-          </Grid.ColumnDefinitions>
-          <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="HorizontalResizeSupported:" />
-          <CheckBox Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" x:Name="HorizontalResizeSupportedCheckBox" Padding="2" Checked="HorizontalResizeSupportedCheckBox_Checked" Unchecked="HorizontalResizeSupportedCheckBox_Unchecked" />
-        </Grid>
-      </StackPanel>
-      <StackPanel>
-        <Grid Padding="2">
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="5*" />
-          </Grid.ColumnDefinitions>
-          <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="VerticalResizeSupported:" />
-          <CheckBox Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" x:Name="VerticalResizeSupportedCheckBox" Padding="2" Checked="VerticalResizeSupportedCheckBox_Checked" Unchecked="VerticalResizeSupportedCheckBox_Unchecked" />
-        </Grid>
-      </StackPanel>
-      <StackPanel>
-        <Grid Padding="2">
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="5*" />
-          </Grid.ColumnDefinitions>
-          <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="PinningSupported:" />
-          <CheckBox Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" x:Name="PinningSupportedCheckBox" Padding="2" Checked="PinningSupportedCheckBox_Checked" Unchecked="PinningSupportedCheckBox_Unchecked" />
-        </Grid>
-      </StackPanel>
-      <StackPanel>
-        <Grid Padding="2">
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="5*" />
-          </Grid.ColumnDefinitions>
-          <TextBlock Grid.Column="0" Grid.Row="0" VerticalAlignment="Center" Text="SettingsSupported:" />
-          <CheckBox Grid.Column="1" Grid.Row="0" VerticalAlignment="Center" x:Name="SettingsSupportedCheckBox" Padding="2" Checked="SettingsSupportedCheckBox_Checked" Unchecked="SettingsSupportedCheckBox_Unchecked" />
-        </Grid>
-      </StackPanel>
-      <Grid Padding="2">
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" />
-          <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-          <RowDefinition />
-          <RowDefinition />
-        </Grid.RowDefinitions>
-        <TextBlock Grid.Column="0" Grid.Row="0" Text="Min Window Width: " VerticalAlignment="Center" />
-        <TextBox Grid.Column="1" Grid.Row="0" x:Name="MinWindowWidthBox" VerticalAlignment="Center" />
-        <TextBlock Grid.Column="0" Grid.Row="1" Text="Min Window Height: " VerticalAlignment="Center" />
-        <TextBox Grid.Column="1" Grid.Row="1" x:Name="MinWindowHeightBox" VerticalAlignment="Center" />
-      </Grid>
-      <Button x:Name="MinWindowSizeButton" Click="MinWindowSize_Click" Margin="0,2">Set MinWindowSize</Button>
-      <Grid Padding="2">
-        <Grid.ColumnDefinitions>
-          <ColumnDefinition Width="Auto" />
-          <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
-        <Grid.RowDefinitions>
-          <RowDefinition />
-          <RowDefinition />
-        </Grid.RowDefinitions>
-        <TextBlock Grid.Column="0" Grid.Row="0" Text="Max Window Width: " VerticalAlignment="Center" />
-        <TextBox Grid.Column="1" Grid.Row="0" x:Name="MaxWindowWidthBox" VerticalAlignment="Center" />
-        <TextBlock Grid.Column="0" Grid.Row="1" Text="Max Window Height: " VerticalAlignment="Center" />
-        <TextBox Grid.Column="1" Grid.Row="1" x:Name="MaxWindowHeightBox" VerticalAlignment="Center" />
-      </Grid>
-      <Button x:Name="MaxWindowSizeButton" Click="MaxWindowSize_Click" Margin="0,2">Set MaxWindowSize</Button>
-    </StackPanel>
-  </ScrollViewer>
+    <Grid>
+        <Grid x:Name="BackgroundGrid" />
+
+        <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Visible">
+            <StackPanel Padding="10" Orientation="Vertical">
+                <Grid Padding="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="AppId: " />
+                    <TextBox
+                        x:Name="ActivateAsyncAppId"
+                        Grid.Column="1"
+                        Text="App" />
+                </Grid>
+                <Grid Padding="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="AppExtensionId: " />
+                    <TextBox
+                        x:Name="ActivateAsyncAppExtId"
+                        Grid.Column="1"
+                        Text="Widget2" />
+                </Grid>
+                <StackPanel
+                    Padding="2"
+                    HorizontalAlignment="Left"
+                    Orientation="Vertical">
+                    <Button
+                        x:Name="ActivateAsyncAppExtIdButton"
+                        Margin="0,2"
+                        Click="ActivateAsyncAppExtIdButton_Click">
+                        ActivateAsync(appExtensionId)
+                    </Button>
+                    <Button
+                        x:Name="ActivateAsyncAppIdButton"
+                        Margin="0,2"
+                        Click="ActivateAsyncAppIdButton_Click">
+                        ActivateAsync(appId, appExtensionId)
+                    </Button>
+                    <Button
+                        x:Name="MinimizeAsyncAppExtIdButton"
+                        Margin="0,2"
+                        Click="MinimizeAsyncAppExtIdButton_Click">
+                        MinimizeAsync(appExtensionId)
+                    </Button>
+                    <Button
+                        x:Name="MinimizeAsyncAppIdButton"
+                        Margin="0,2"
+                        Click="MinimizeAsyncAppIdButton_Click">
+                        MinimizeAsync(appId, appExtensionId)
+                    </Button>
+                    <Button
+                        x:Name="RestoreAsyncAppExtIdButton"
+                        Margin="0,2"
+                        Click="RestoreAsyncAppExtIdButton_Click">
+                        RestoreAsync(appExtensionId)
+                    </Button>
+                    <Button
+                        x:Name="RestoreAsyncAppIdButton"
+                        Margin="0,2"
+                        Click="RestoreAsyncAppIdButton_Click">
+                        RestoreAsync(appId, appExtensionId)
+                    </Button>
+                    <Button
+                        x:Name="CloseAsyncAppExtIdButton"
+                        Margin="0,2"
+                        Click="CloseAsyncAppExtIdButton_Click">
+                        CloseAsync(appExtensionId)
+                    </Button>
+                    <Button
+                        x:Name="CloseAsyncAppIdButton"
+                        Margin="0,2"
+                        Click="CloseAsyncAppIdButton_Click">
+                        CloseAsync(appId, appExtensionId)
+                    </Button>
+                </StackPanel>
+                <Grid Padding="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="Uri: " />
+                    <TextBox
+                        x:Name="ActivateAsyncUri"
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        Text="ms-gamebar:activate/WidgetAdvSampleCS_8wekyb3d8bbwe_App_Widget2/?var=value" />
+                </Grid>
+                <Button
+                    x:Name="ActivateWithUriAsyncButton"
+                    Margin="0,2"
+                    Click="ActivateWithUriAsyncButton_Click">
+                    ActivateWithUriAsync(uri)
+                </Button>
+                <Grid Padding="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+                    <TextBlock
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="Window Width: " />
+                    <TextBox
+                        x:Name="WindowWidthBox"
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        Text="800" />
+                    <TextBlock
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="Window Height: " />
+                    <TextBox
+                        x:Name="WindowHeightBox"
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        VerticalAlignment="Center"
+                        Text="800" />
+                </Grid>
+                <Button
+                    x:Name="TryResizeWindowAsync"
+                    Margin="0,2"
+                    Click="TryResizeWindowAsync_Click">
+                    TryResizeWindowAsync
+                </Button>
+                <Grid Padding="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+                    <TextBlock
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="Request URI: " />
+                    <TextBox
+                        x:Name="RequestUriBox"
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        VerticalAlignment="Center" />
+                    <TextBlock
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="Callback URI: " />
+                    <TextBox
+                        x:Name="CallbackUriBox"
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        VerticalAlignment="Center" />
+                </Grid>
+                <Button
+                    x:Name="AuthenticateAsync"
+                    Margin="0,2"
+                    Click="AuthenticateAsync_Click">
+                    AuthenticateAsync
+                </Button>
+                <StackPanel>
+                    <Grid Padding="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="5*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Text="Pinned:" />
+                        <TextBlock
+                            x:Name="PinnedStateTextBlock"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            VerticalAlignment="Center" />
+                    </Grid>
+                </StackPanel>
+                <StackPanel>
+                    <Grid Padding="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="5*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Text="Opacity:" />
+                        <TextBlock
+                            x:Name="RequestedOpacityTextBlock"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            VerticalAlignment="Center" />
+                    </Grid>
+                </StackPanel>
+                <StackPanel>
+                    <Grid Padding="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="5*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Text="Theme:" />
+                        <TextBlock
+                            x:Name="RequestedThemeTextBlock"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            VerticalAlignment="Center" />
+                    </Grid>
+                </StackPanel>
+                <StackPanel>
+                    <Grid Padding="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="5*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Text="Favorited:" />
+                        <TextBlock
+                            x:Name="FavoritedTextBlock"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            VerticalAlignment="Center" />
+                    </Grid>
+                </StackPanel>
+                <StackPanel>
+                    <Grid Padding="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="5*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Text="HorizontalResizeSupported:" />
+                        <CheckBox
+                            x:Name="HorizontalResizeSupportedCheckBox"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            Padding="2"
+                            VerticalAlignment="Center"
+                            Checked="HorizontalResizeSupportedCheckBox_Checked"
+                            Unchecked="HorizontalResizeSupportedCheckBox_Unchecked" />
+                    </Grid>
+                </StackPanel>
+                <StackPanel>
+                    <Grid Padding="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="5*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Text="VerticalResizeSupported:" />
+                        <CheckBox
+                            x:Name="VerticalResizeSupportedCheckBox"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            Padding="2"
+                            VerticalAlignment="Center"
+                            Checked="VerticalResizeSupportedCheckBox_Checked"
+                            Unchecked="VerticalResizeSupportedCheckBox_Unchecked" />
+                    </Grid>
+                </StackPanel>
+                <StackPanel>
+                    <Grid Padding="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="5*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Text="PinningSupported:" />
+                        <CheckBox
+                            x:Name="PinningSupportedCheckBox"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            Padding="2"
+                            VerticalAlignment="Center"
+                            Checked="PinningSupportedCheckBox_Checked"
+                            Unchecked="PinningSupportedCheckBox_Unchecked" />
+                    </Grid>
+                </StackPanel>
+                <StackPanel>
+                    <Grid Padding="2">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="5*" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Text="SettingsSupported:" />
+                        <CheckBox
+                            x:Name="SettingsSupportedCheckBox"
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            Padding="2"
+                            VerticalAlignment="Center"
+                            Checked="SettingsSupportedCheckBox_Checked"
+                            Unchecked="SettingsSupportedCheckBox_Unchecked" />
+                    </Grid>
+                </StackPanel>
+                <Grid Padding="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+                    <TextBlock
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="Min Window Width: " />
+                    <TextBox
+                        x:Name="MinWindowWidthBox"
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        VerticalAlignment="Center" />
+                    <TextBlock
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="Min Window Height: " />
+                    <TextBox
+                        x:Name="MinWindowHeightBox"
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        VerticalAlignment="Center" />
+                </Grid>
+                <Button
+                    x:Name="MinWindowSizeButton"
+                    Margin="0,2"
+                    Click="MinWindowSize_Click">
+                    Set MinWindowSize
+                </Button>
+                <Grid Padding="2">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition />
+                        <RowDefinition />
+                    </Grid.RowDefinitions>
+                    <TextBlock
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="Max Window Width: " />
+                    <TextBox
+                        x:Name="MaxWindowWidthBox"
+                        Grid.Row="0"
+                        Grid.Column="1"
+                        VerticalAlignment="Center" />
+                    <TextBlock
+                        Grid.Row="1"
+                        Grid.Column="0"
+                        VerticalAlignment="Center"
+                        Text="Max Window Height: " />
+                    <TextBox
+                        x:Name="MaxWindowHeightBox"
+                        Grid.Row="1"
+                        Grid.Column="1"
+                        VerticalAlignment="Center" />
+                </Grid>
+                <Button
+                    x:Name="MaxWindowSizeButton"
+                    Margin="0,2"
+                    Click="MaxWindowSize_Click">
+                    Set MaxWindowSize
+                </Button>
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
 </Page>

--- a/Samples/WidgetAdvSampleCS/Widget1.xaml.cs
+++ b/Samples/WidgetAdvSampleCS/Widget1.xaml.cs
@@ -49,6 +49,7 @@ namespace WidgetAdvSampleCS
             widget.SettingsClicked += Widget_SettingsClicked;
             widget.PinnedChanged += Widget_PinnedChanged;
             widget.FavoritedChanged += Widget_FavoritedChanged;
+            widget.RequestedOpacityChanged += Widget_RequestedOpacityChanged;
             widget.RequestedThemeChanged += Widget_RequestedThemeChanged;
             widget.VisibleChanged += Widget_VisibleChanged;
             widget.WindowStateChanged += Widget_WindowStateChanged;
@@ -56,11 +57,13 @@ namespace WidgetAdvSampleCS
 
             SetPinnedStateTextBox();
             SetFavoritedState();
+            SetRequestedOpacityState();
             SetRequestedThemeState();
             OutputVisibleState();
             OutputWindowState();
             OutputGameBarDisplayMode();
             SetBackgroundColor();
+            SetBackgroundOpacity();
 
             HorizontalResizeSupportedCheckBox.IsChecked = widget.HorizontalResizeSupported;
             VerticalResizeSupportedCheckBox.IsChecked = widget.VerticalResizeSupported;
@@ -238,6 +241,15 @@ namespace WidgetAdvSampleCS
             });
         }
 
+        private async void Widget_RequestedOpacityChanged(XboxGameBarWidget sender, object args)
+        {
+            await RequestedOpacityTextBlock.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
+            {
+                SetRequestedOpacityState();
+                SetBackgroundOpacity();
+            });
+        }
+
         private async void Widget_RequestedThemeChanged(XboxGameBarWidget sender, object args)
         {
             await RequestedThemeTextBlock.Dispatcher.RunAsync(Windows.UI.Core.CoreDispatcherPriority.Normal, () =>
@@ -246,6 +258,7 @@ namespace WidgetAdvSampleCS
                 SetBackgroundColor();
             });
         }
+
         private void Widget_VisibleChanged(XboxGameBarWidget sender, object args)
         {
             OutputVisibleState();
@@ -274,7 +287,17 @@ namespace WidgetAdvSampleCS
         private void SetBackgroundColor()
         {
             this.RequestedTheme = widget.RequestedTheme;
-            this.Background = (widget.RequestedTheme == ElementTheme.Dark) ? widgetBlackBrush : widgetWhiteBrush;
+            BackgroundGrid.Background = (widget.RequestedTheme == ElementTheme.Dark) ? widgetBlackBrush : widgetWhiteBrush;
+        }
+
+        private void SetBackgroundOpacity()
+        {
+            BackgroundGrid.Opacity = widget.RequestedOpacity;
+        }
+
+        private void SetRequestedOpacityState()
+        {
+            RequestedOpacityTextBlock.Text = widget.RequestedOpacity.ToString();
         }
 
         private void SetRequestedThemeState()

--- a/Samples/WidgetAdvSampleCS/Widget1Settings.xaml
+++ b/Samples/WidgetAdvSampleCS/Widget1Settings.xaml
@@ -2,14 +2,20 @@
     x:Class="WidgetAdvSampleCS.Widget1Settings"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetAdvSampleCS"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WidgetAdvSampleCS"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    mc:Ignorable="d">
 
-    <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <TextBlock Text="Widget1Settings" Padding="0,0,0,5"/>
-        <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
-    </StackPanel>
+    <Grid>
+        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
+
+        <StackPanel
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Orientation="Vertical">
+            <TextBlock Padding="0,0,0,5" Text="Widget1Settings" />
+            <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
+        </StackPanel>
+    </Grid>
 </Page>

--- a/Samples/WidgetAdvSampleCS/Widget2.xaml
+++ b/Samples/WidgetAdvSampleCS/Widget2.xaml
@@ -2,16 +2,25 @@
     x:Class="WidgetAdvSampleCS.Widget2"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetAdvSampleCS"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WidgetAdvSampleCS"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    mc:Ignorable="d">
 
-    <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <TextBlock Text="Widget2" Padding="0,0,0,5"/>
-        <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
-        <TextBlock FontWeight="Bold" Text="Activation URI: " Margin="0,5,0,2"/>
-        <TextBlock x:Name="uriTextBlock" TextWrapping="WrapWholeWords" />
-    </StackPanel>
+    <Grid>
+        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
+
+        <StackPanel
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Orientation="Vertical">
+            <TextBlock Padding="0,0,0,5" Text="Widget2" />
+            <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
+            <TextBlock
+                Margin="0,5,0,2"
+                FontWeight="Bold"
+                Text="Activation URI: " />
+            <TextBlock x:Name="uriTextBlock" TextWrapping="WrapWholeWords" />
+        </StackPanel>
+    </Grid>
 </Page>

--- a/Samples/WidgetAdvSampleCS/WidgetAdvSampleCS.csproj
+++ b/Samples/WidgetAdvSampleCS/WidgetAdvSampleCS.csproj
@@ -194,7 +194,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Gaming.XboxGameBar">
-      <Version>5.1.200401003</Version>
+      <Version>5.3.200511002</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.9</Version>

--- a/Samples/WidgetAdvSampleCS/WidgetAdvSampleCS.csproj
+++ b/Samples/WidgetAdvSampleCS/WidgetAdvSampleCS.csproj
@@ -194,7 +194,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Gaming.XboxGameBar">
-      <Version>5.3.200511002</Version>
+      <Version>5.3.200512001-prerelease</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.9</Version>

--- a/Samples/WidgetSample/App.xaml
+++ b/Samples/WidgetSample/App.xaml
@@ -2,6 +2,4 @@
     x:Class="WidgetSample.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetSample">
-
-</Application>
+    xmlns:local="using:WidgetSample" />

--- a/Samples/WidgetSample/MainPage.xaml
+++ b/Samples/WidgetSample/MainPage.xaml
@@ -2,13 +2,16 @@
     x:Class="WidgetSample.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetSample"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WidgetSample"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <TextBlock Text="MainPage" Padding="0,0,0,5"/>
-       <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
+    <StackPanel
+        HorizontalAlignment="Center"
+        VerticalAlignment="Center"
+        Orientation="Vertical">
+        <TextBlock Padding="0,0,0,5" Text="MainPage" />
+        <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
     </StackPanel>
 </Page>

--- a/Samples/WidgetSample/Package.appxmanifest
+++ b/Samples/WidgetSample/Package.appxmanifest
@@ -80,6 +80,7 @@
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarNavigationKeyCombo" InterfaceId="5EEA3DBF-09BB-42A5-B491-CF561E33C172" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetActivatedEventArgsPrivate" InterfaceId="782535A7-9407-4572-BFCB-316B4086F102" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost" InterfaceId="5D12BC93-212B-4B9F-9091-76B73BF56525" />
+        <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost2" InterfaceId="28717C8B-D8E8-47A8-AF47-A1D5263BAE9B" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate" InterfaceId="22ABA97F-FB0F-4439-9BDD-2C67B2D5AA8F" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate2" InterfaceId="B2F7DB8C-7540-48DA-9B46-4E60CE0D9DEB" />
       </ProxyStub>

--- a/Samples/WidgetSample/Package.appxmanifest
+++ b/Samples/WidgetSample/Package.appxmanifest
@@ -81,6 +81,7 @@
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetActivatedEventArgsPrivate" InterfaceId="782535A7-9407-4572-BFCB-316B4086F102" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost" InterfaceId="5D12BC93-212B-4B9F-9091-76B73BF56525" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate" InterfaceId="22ABA97F-FB0F-4439-9BDD-2C67B2D5AA8F" />
+        <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate2" InterfaceId="B2F7DB8C-7540-48DA-9B46-4E60CE0D9DEB" />
       </ProxyStub>
     </Extension>
   </Extensions>

--- a/Samples/WidgetSample/Widget1.xaml
+++ b/Samples/WidgetSample/Widget1.xaml
@@ -2,13 +2,20 @@
     x:Class="WidgetSample.Widget1"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetSample"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WidgetSample"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <TextBlock Text="Widget1" Padding="0,0,0,5"/>
-       <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
-    </StackPanel>
+    <Grid>
+        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
+
+        <StackPanel
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Orientation="Vertical">
+            <TextBlock Padding="0,0,0,5" Text="Widget1" />
+            <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
+        </StackPanel>
+    </Grid>
 </Page>

--- a/Samples/WidgetSample/WidgetSample.vcxproj
+++ b/Samples/WidgetSample/WidgetSample.vcxproj
@@ -172,7 +172,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets" Condition="Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets')" />
+    <Import Project="..\packages\Microsoft.Gaming.XboxGameBar.5.3.200512001-prerelease\build\native\Microsoft.Gaming.XboxGameBar.targets" Condition="Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200512001-prerelease\build\native\Microsoft.Gaming.XboxGameBar.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -180,6 +180,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200512001-prerelease\build\native\Microsoft.Gaming.XboxGameBar.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Gaming.XboxGameBar.5.3.200512001-prerelease\build\native\Microsoft.Gaming.XboxGameBar.targets'))" />
   </Target>
 </Project>

--- a/Samples/WidgetSample/WidgetSample.vcxproj
+++ b/Samples/WidgetSample/WidgetSample.vcxproj
@@ -172,7 +172,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Microsoft.Gaming.XboxGameBar.5.1.200401003\build\native\Microsoft.Gaming.XboxGameBar.targets" Condition="Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.1.200401003\build\native\Microsoft.Gaming.XboxGameBar.targets')" />
+    <Import Project="..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets" Condition="Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -180,6 +180,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.1.200401003\build\native\Microsoft.Gaming.XboxGameBar.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Gaming.XboxGameBar.5.1.200401003\build\native\Microsoft.Gaming.XboxGameBar.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets'))" />
   </Target>
 </Project>

--- a/Samples/WidgetSample/packages.config
+++ b/Samples/WidgetSample/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Gaming.XboxGameBar" version="5.3.200511002" targetFramework="native" />
+  <package id="Microsoft.Gaming.XboxGameBar" version="5.3.200512001-prerelease" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200203.5" targetFramework="native" />
 </packages>

--- a/Samples/WidgetSample/packages.config
+++ b/Samples/WidgetSample/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Gaming.XboxGameBar" version="5.1.200401003" targetFramework="native" />
+  <package id="Microsoft.Gaming.XboxGameBar" version="5.3.200511002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200203.5" targetFramework="native" />
 </packages>

--- a/Samples/WidgetSampleCS/App.xaml
+++ b/Samples/WidgetSampleCS/App.xaml
@@ -2,6 +2,4 @@
     x:Class="WidgetSampleCS.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetSampleCS">
-
-</Application>
+    xmlns:local="using:WidgetSampleCS" />

--- a/Samples/WidgetSampleCS/MainPage.xaml
+++ b/Samples/WidgetSampleCS/MainPage.xaml
@@ -2,14 +2,17 @@
     x:Class="WidgetSampleCS.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetSampleCS"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WidgetSampleCS"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
 
-    <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <TextBlock Text="MainPage" Padding="0,0,0,5"/>
+    <StackPanel
+        HorizontalAlignment="Center"
+        VerticalAlignment="Center"
+        Orientation="Vertical">
+        <TextBlock Padding="0,0,0,5" Text="MainPage" />
         <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
     </StackPanel>
 </Page>

--- a/Samples/WidgetSampleCS/Package.appxmanifest
+++ b/Samples/WidgetSampleCS/Package.appxmanifest
@@ -86,6 +86,7 @@
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarNavigationKeyCombo" InterfaceId="5EEA3DBF-09BB-42A5-B491-CF561E33C172" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetActivatedEventArgsPrivate" InterfaceId="782535A7-9407-4572-BFCB-316B4086F102" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost" InterfaceId="5D12BC93-212B-4B9F-9091-76B73BF56525" />
+        <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost2" InterfaceId="28717C8B-D8E8-47A8-AF47-A1D5263BAE9B" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate" InterfaceId="22ABA97F-FB0F-4439-9BDD-2C67B2D5AA8F" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate2" InterfaceId="B2F7DB8C-7540-48DA-9B46-4E60CE0D9DEB" />
       </ProxyStub>

--- a/Samples/WidgetSampleCS/Package.appxmanifest
+++ b/Samples/WidgetSampleCS/Package.appxmanifest
@@ -87,6 +87,7 @@
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetActivatedEventArgsPrivate" InterfaceId="782535A7-9407-4572-BFCB-316B4086F102" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost" InterfaceId="5D12BC93-212B-4B9F-9091-76B73BF56525" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate" InterfaceId="22ABA97F-FB0F-4439-9BDD-2C67B2D5AA8F" />
+        <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate2" InterfaceId="B2F7DB8C-7540-48DA-9B46-4E60CE0D9DEB" />
       </ProxyStub>
     </Extension>
   </Extensions>

--- a/Samples/WidgetSampleCS/Widget1.xaml
+++ b/Samples/WidgetSampleCS/Widget1.xaml
@@ -2,14 +2,20 @@
     x:Class="WidgetSampleCS.Widget1"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetSampleCS"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WidgetSampleCS"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    mc:Ignorable="d">
 
-    <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <TextBlock Text="Widget1" Padding="0,0,0,5"/>
-        <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
-    </StackPanel>
+    <Grid>
+        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
+
+        <StackPanel
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Orientation="Vertical">
+            <TextBlock Padding="0,0,0,5" Text="Widget1" />
+            <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
+        </StackPanel>
+    </Grid>
 </Page>

--- a/Samples/WidgetSampleCS/WidgetSampleCS.csproj
+++ b/Samples/WidgetSampleCS/WidgetSampleCS.csproj
@@ -180,7 +180,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Gaming.XboxGameBar">
-      <Version>5.3.200511002</Version>
+      <Version>5.3.200512001-prerelease</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.9</Version>

--- a/Samples/WidgetSampleCS/WidgetSampleCS.csproj
+++ b/Samples/WidgetSampleCS/WidgetSampleCS.csproj
@@ -180,7 +180,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Gaming.XboxGameBar">
-      <Version>5.1.200401003</Version>
+      <Version>5.3.200511002</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.9</Version>

--- a/Samples/WidgetSampleCX/App.xaml
+++ b/Samples/WidgetSampleCX/App.xaml
@@ -2,6 +2,4 @@
     x:Class="WidgetSampleCX.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetSampleCX">
-
-</Application>
+    xmlns:local="using:WidgetSampleCX" />

--- a/Samples/WidgetSampleCX/MainPage.xaml
+++ b/Samples/WidgetSampleCX/MainPage.xaml
@@ -2,14 +2,17 @@
     x:Class="WidgetSampleCX.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetSampleCX"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WidgetSampleCX"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
 
-    <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <TextBlock Text="MainPage" Padding="0,0,0,5"/>
+    <StackPanel
+        HorizontalAlignment="Center"
+        VerticalAlignment="Center"
+        Orientation="Vertical">
+        <TextBlock Padding="0,0,0,5" Text="MainPage" />
         <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
     </StackPanel>
 </Page>

--- a/Samples/WidgetSampleCX/Package.appxmanifest
+++ b/Samples/WidgetSampleCX/Package.appxmanifest
@@ -86,6 +86,7 @@
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarNavigationKeyCombo" InterfaceId="5EEA3DBF-09BB-42A5-B491-CF561E33C172" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetActivatedEventArgsPrivate" InterfaceId="782535A7-9407-4572-BFCB-316B4086F102" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost" InterfaceId="5D12BC93-212B-4B9F-9091-76B73BF56525" />
+        <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost2" InterfaceId="28717C8B-D8E8-47A8-AF47-A1D5263BAE9B" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate" InterfaceId="22ABA97F-FB0F-4439-9BDD-2C67B2D5AA8F" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate2" InterfaceId="B2F7DB8C-7540-48DA-9B46-4E60CE0D9DEB" />
       </ProxyStub>

--- a/Samples/WidgetSampleCX/Package.appxmanifest
+++ b/Samples/WidgetSampleCX/Package.appxmanifest
@@ -87,6 +87,7 @@
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetActivatedEventArgsPrivate" InterfaceId="782535A7-9407-4572-BFCB-316B4086F102" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost" InterfaceId="5D12BC93-212B-4B9F-9091-76B73BF56525" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate" InterfaceId="22ABA97F-FB0F-4439-9BDD-2C67B2D5AA8F" />
+        <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate2" InterfaceId="B2F7DB8C-7540-48DA-9B46-4E60CE0D9DEB" />
       </ProxyStub>
     </Extension>
   </Extensions>

--- a/Samples/WidgetSampleCX/Widget1.xaml
+++ b/Samples/WidgetSampleCX/Widget1.xaml
@@ -2,14 +2,20 @@
     x:Class="WidgetSampleCX.Widget1"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetSampleCX"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WidgetSampleCX"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    mc:Ignorable="d">
 
-    <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <TextBlock Text="Widget1" Padding="0,0,0,5"/>
-        <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
-    </StackPanel>
+    <Grid>
+        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
+
+        <StackPanel
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Orientation="Vertical">
+            <TextBlock Padding="0,0,0,5" Text="Widget1" />
+            <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
+        </StackPanel>
+    </Grid>
 </Page>

--- a/Samples/WidgetSampleCX/WidgetSampleCX.vcxproj
+++ b/Samples/WidgetSampleCX/WidgetSampleCX.vcxproj
@@ -228,12 +228,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets" Condition="Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets')" />
+    <Import Project="..\packages\Microsoft.Gaming.XboxGameBar.5.3.200512001-prerelease\build\native\Microsoft.Gaming.XboxGameBar.targets" Condition="Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200512001-prerelease\build\native\Microsoft.Gaming.XboxGameBar.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200512001-prerelease\build\native\Microsoft.Gaming.XboxGameBar.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Gaming.XboxGameBar.5.3.200512001-prerelease\build\native\Microsoft.Gaming.XboxGameBar.targets'))" />
   </Target>
 </Project>

--- a/Samples/WidgetSampleCX/WidgetSampleCX.vcxproj
+++ b/Samples/WidgetSampleCX/WidgetSampleCX.vcxproj
@@ -228,12 +228,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.Gaming.XboxGameBar.5.1.200401003\build\native\Microsoft.Gaming.XboxGameBar.targets" Condition="Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.1.200401003\build\native\Microsoft.Gaming.XboxGameBar.targets')" />
+    <Import Project="..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets" Condition="Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.1.200401003\build\native\Microsoft.Gaming.XboxGameBar.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Gaming.XboxGameBar.5.1.200401003\build\native\Microsoft.Gaming.XboxGameBar.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets'))" />
   </Target>
 </Project>

--- a/Samples/WidgetSampleCX/packages.config
+++ b/Samples/WidgetSampleCX/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Gaming.XboxGameBar" version="5.1.200401003" targetFramework="native" />
+  <package id="Microsoft.Gaming.XboxGameBar" version="5.3.200511002" targetFramework="native" />
 </packages>

--- a/Samples/WidgetSampleCX/packages.config
+++ b/Samples/WidgetSampleCX/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Gaming.XboxGameBar" version="5.3.200511002" targetFramework="native" />
+  <package id="Microsoft.Gaming.XboxGameBar" version="5.3.200512001-prerelease" targetFramework="native" />
 </packages>

--- a/Samples/WidgetSettingsSample/App.xaml
+++ b/Samples/WidgetSettingsSample/App.xaml
@@ -2,6 +2,4 @@
     x:Class="WidgetSettingsSample.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetSettingsSample">
-
-</Application>
+    xmlns:local="using:WidgetSettingsSample" />

--- a/Samples/WidgetSettingsSample/MainPage.xaml
+++ b/Samples/WidgetSettingsSample/MainPage.xaml
@@ -2,13 +2,16 @@
     x:Class="WidgetSettingsSample.MainPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetSettingsSample"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WidgetSettingsSample"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <TextBlock Text="MainPage" Padding="0,0,0,5"/>
-       <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
+    <StackPanel
+        HorizontalAlignment="Center"
+        VerticalAlignment="Center"
+        Orientation="Vertical">
+        <TextBlock Padding="0,0,0,5" Text="MainPage" />
+        <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
     </StackPanel>
 </Page>

--- a/Samples/WidgetSettingsSample/Package.appxmanifest
+++ b/Samples/WidgetSettingsSample/Package.appxmanifest
@@ -104,6 +104,7 @@
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetActivatedEventArgsPrivate" InterfaceId="782535A7-9407-4572-BFCB-316B4086F102" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost" InterfaceId="5D12BC93-212B-4B9F-9091-76B73BF56525" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate" InterfaceId="22ABA97F-FB0F-4439-9BDD-2C67B2D5AA8F" />
+        <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate2" InterfaceId="B2F7DB8C-7540-48DA-9B46-4E60CE0D9DEB" />
       </ProxyStub>
     </Extension>
   </Extensions>

--- a/Samples/WidgetSettingsSample/Package.appxmanifest
+++ b/Samples/WidgetSettingsSample/Package.appxmanifest
@@ -103,6 +103,7 @@
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarNavigationKeyCombo" InterfaceId="5EEA3DBF-09BB-42A5-B491-CF561E33C172" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetActivatedEventArgsPrivate" InterfaceId="782535A7-9407-4572-BFCB-316B4086F102" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost" InterfaceId="5D12BC93-212B-4B9F-9091-76B73BF56525" />
+        <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetHost2" InterfaceId="28717C8B-D8E8-47A8-AF47-A1D5263BAE9B" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate" InterfaceId="22ABA97F-FB0F-4439-9BDD-2C67B2D5AA8F" />
         <Interface Name="Microsoft.Gaming.XboxGameBar.Private.IXboxGameBarWidgetPrivate2" InterfaceId="B2F7DB8C-7540-48DA-9B46-4E60CE0D9DEB" />
       </ProxyStub>

--- a/Samples/WidgetSettingsSample/Widget.xaml
+++ b/Samples/WidgetSettingsSample/Widget.xaml
@@ -2,14 +2,20 @@
     x:Class="WidgetSettingsSample.Widget"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetSettingsSample"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WidgetSettingsSample"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
 
-    <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <TextBlock Text="Widget" Padding="0,0,0,5"/>
-        <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
-    </StackPanel>
+    <Grid>
+        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
 
+        <StackPanel
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Orientation="Vertical">
+            <TextBlock Padding="0,0,0,5" Text="Widget" />
+            <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
+        </StackPanel>
+    </Grid>
 </Page>

--- a/Samples/WidgetSettingsSample/WidgetSettings.xaml
+++ b/Samples/WidgetSettingsSample/WidgetSettings.xaml
@@ -2,14 +2,20 @@
     x:Class="WidgetSettingsSample.WidgetSettings"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:WidgetSettingsSample"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:WidgetSettingsSample"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    mc:Ignorable="d">
 
-    <StackPanel Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
-        <TextBlock Text="WidgetSettings" Padding="0,0,0,5"/>
-        <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
-    </StackPanel>
+    <Grid>
+        <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" />
+
+        <StackPanel
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Orientation="Vertical">
+            <TextBlock Padding="0,0,0,5" Text="WidgetSettings" />
+            <Button x:Name="myButton" Click="MyButton_Click">Click Me</Button>
+        </StackPanel>
+    </Grid>
 </Page>

--- a/Samples/WidgetSettingsSample/WidgetSettingsSample.vcxproj
+++ b/Samples/WidgetSettingsSample/WidgetSettingsSample.vcxproj
@@ -230,7 +230,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets" Condition="Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets')" />
+    <Import Project="..\packages\Microsoft.Gaming.XboxGameBar.5.3.200512001-prerelease\build\native\Microsoft.Gaming.XboxGameBar.targets" Condition="Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200512001-prerelease\build\native\Microsoft.Gaming.XboxGameBar.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -238,6 +238,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200512001-prerelease\build\native\Microsoft.Gaming.XboxGameBar.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Gaming.XboxGameBar.5.3.200512001-prerelease\build\native\Microsoft.Gaming.XboxGameBar.targets'))" />
   </Target>
 </Project>

--- a/Samples/WidgetSettingsSample/WidgetSettingsSample.vcxproj
+++ b/Samples/WidgetSettingsSample/WidgetSettingsSample.vcxproj
@@ -230,7 +230,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets')" />
-    <Import Project="..\packages\Microsoft.Gaming.XboxGameBar.5.1.200401003\build\native\Microsoft.Gaming.XboxGameBar.targets" Condition="Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.1.200401003\build\native\Microsoft.Gaming.XboxGameBar.targets')" />
+    <Import Project="..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets" Condition="Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
@@ -238,6 +238,6 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.2.0.200203.5\build\native\Microsoft.Windows.CppWinRT.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.1.200401003\build\native\Microsoft.Gaming.XboxGameBar.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Gaming.XboxGameBar.5.1.200401003\build\native\Microsoft.Gaming.XboxGameBar.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Gaming.XboxGameBar.5.3.200511002\build\native\Microsoft.Gaming.XboxGameBar.targets'))" />
   </Target>
 </Project>

--- a/Samples/WidgetSettingsSample/packages.config
+++ b/Samples/WidgetSettingsSample/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Gaming.XboxGameBar" version="5.3.200511002" targetFramework="native" />
+  <package id="Microsoft.Gaming.XboxGameBar" version="5.3.200512001-prerelease" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200203.5" targetFramework="native" />
 </packages>

--- a/Samples/WidgetSettingsSample/packages.config
+++ b/Samples/WidgetSettingsSample/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Gaming.XboxGameBar" version="5.1.200401003" targetFramework="native" />
+  <package id="Microsoft.Gaming.XboxGameBar" version="5.3.200511002" targetFramework="native" />
   <package id="Microsoft.Windows.CppWinRT" version="2.0.200203.5" targetFramework="native" />
 </packages>


### PR DESCRIPTION
This change updates the two advanced samples to show you a widget developer can plug into user-configurable transparency settings.

A combination of the RequestedOpacity property and the RequestedOpacityChanged event can be used to update the widget background to match how the built-in Game Bar widgets will behave when Game Bar is in PinnedOnly mode.

Additional changes:
- Formatted all XAML files to be more consistent
- Added backgrounds to widgets that didn't have them