### PR TITLE
Fix padding on root grids

### DIFF
--- a/Samples/WidgetAdvSample/Widget1.xaml
+++ b/Samples/WidgetAdvSample/Widget1.xaml
@@ -49,8 +49,8 @@
         </Style>
     </Page.Resources>
 
-    <Grid x:Name="RootGrid">
-        <Grid x:Name="BackgroundGrid" />
+    <Grid x:Name="RootGrid" Padding="0">
+        <Grid x:Name="BackgroundGrid" Padding="0" />
         <ScrollViewer
             x:Name="RootScrollViewer"
             HorizontalScrollBarVisibility="Auto"

--- a/Samples/WidgetAdvSampleCS/Widget1.xaml
+++ b/Samples/WidgetAdvSampleCS/Widget1.xaml
@@ -49,8 +49,8 @@
         </Style>
     </Page.Resources>
 
-    <Grid x:Name="RootGrid">
-        <Grid x:Name="BackgroundGrid" />
+    <Grid x:Name="RootGrid" Padding="0">
+        <Grid x:Name="BackgroundGrid" Padding="0" />
         <ScrollViewer
             x:Name="RootScrollViewer"
             HorizontalScrollBarVisibility="Auto"


### PR DESCRIPTION
Due to default 1px padding on grids, the backplate grid had padding that exposed transparent 1px border from host view. Update padding on root grids to 0. 